### PR TITLE
Add open in current dir option, remove all proxy files before leaving.

### DIFF
--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -74,8 +74,8 @@ function! vimpyter#createView()
   let l:original_dir = substitute(expand('%:p:h'), '\ ', '\\ ', 'g')
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
-  let l:proxy_file_name = '~$' . expand('%:t:r')
-  let l:proxy_buffer_name = substitute(s:checkNameExistence(l:proxy_file_name), '\~\$', '\\~\\$', 'g')
+  let l:proxy_file_name = '.ipynb_tmp.' . expand('%:t:r')
+  let l:proxy_buffer_name = s:checkNameExistence(l:proxy_file_name)
   if g:vimpyter_use_current_dir
     let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
   else

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -91,6 +91,7 @@ function! vimpyter#createView()
 	let b:ipynb_mode = 1
   " Save references to proxy file and the original
   let b:original_file = l:original_file
+  let b:proxy_file = l:proxy_file
   call add(g:vimpyter_proxy_files, l:proxy_file)
   let b:ipynb_on = 1
 

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -61,20 +61,25 @@ function! vimpyter#createView()
     if has_key(g:vimpyter_buffer_names, a:name)
       let l:buffer_name = g:vimpyter_buffer_names[a:name]
       let g:vimpyter_buffer_names[a:name] = l:buffer_name + 1
-      return a:name . string(l:buffer_name) . '.py'
+      return a:name . string(l:buffer_name) . '.py~'
     else
       let g:vimpyter_buffer_names[a:name] = 0
-      return a:name . '.py'
+      return a:name . '.py~'
     endif
     return ''
   endfunction
 
   " Save original file path and create path to proxy
   let l:original_file = substitute(expand('%:p'), '\ ', '\\ ', 'g')
+  let l:original_dir = substitute(expand('%:p:h'), '\ ', '\\ ', 'g')
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
   let l:proxy_buffer_name = s:checkNameExistence(expand('%:t:r'))
-  let l:proxy_file = g:vimpyter_view_directory . '/' . l:proxy_buffer_name
+  if g:vimpyter_use_current_dir
+    let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
+  else
+    let l:proxy_file = g:vimpyter_view_directory . '/' . l:proxy_buffer_name
+  endif
 
   " Transform json to markdown and save the result in proxy
 	call system('ipynb-py-convert ' . l:original_file .

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -123,8 +123,8 @@ function! vimpyter#notebookUpdatesFinished()
   
   " Close proxy buffers before leave
   for proxy_file in g:vimpyter_proxy_files
-    let bufwinnr = bufnr(proxy_file)
-    if bufwinnr != -1
+    let bufnr = bufnr(proxy_file)
+    if bufnr != -1
       execute 'bw ' . bufnr
     endif
   endfor

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -96,7 +96,7 @@ function! vimpyter#createView()
 
 
   " Close original file (it won't be edited directly)
-  silent execute ':bd' l:original_file
+  silent execute ':bw' l:original_file
 
   " SET FILETYPE TO ipynb
   set filetype=python
@@ -119,7 +119,7 @@ function! vimpyter#notebookUpdatesFinished()
       endwhile
     endif
   endif
-  execute ':bd' b:proxy_file
+  execute ':bw' b:proxy_file
   call system('rm ' . b:proxy_file)
 
 endfunction

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -74,8 +74,8 @@ function! vimpyter#createView()
   let l:original_dir = substitute(expand('%:p:h'), '\ ', '\\ ', 'g')
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
-  let l:proxy_file_name = "~$" . expand('%:t:r')
-  let l:proxy_buffer_name = s:checkNameExistence(l:proxy_file_name)
+  let l:proxy_file_name = '~$' . expand('%:t:r')
+  let l:proxy_buffer_name = substitute(s:checkNameExistence(l:proxy_file_name), '~$', '\~\$', 'g')
   if g:vimpyter_use_current_dir
     let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
   else

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -61,10 +61,10 @@ function! vimpyter#createView()
     if has_key(g:vimpyter_buffer_names, a:name)
       let l:buffer_name = g:vimpyter_buffer_names[a:name]
       let g:vimpyter_buffer_names[a:name] = l:buffer_name + 1
-      return a:name . string(l:buffer_name) . '.py~'
+      return a:name . string(l:buffer_name) . '.py'
     else
       let g:vimpyter_buffer_names[a:name] = 0
-      return a:name . '.py~'
+      return a:name . '.py'
     endif
     return ''
   endfunction
@@ -74,7 +74,8 @@ function! vimpyter#createView()
   let l:original_dir = substitute(expand('%:p:h'), '\ ', '\\ ', 'g')
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
-  let l:proxy_buffer_name = s:checkNameExistence(expand('%:t:r'))
+  let l:proxy_file_name = "~$" . expand('%:t:r')
+  let l:proxy_buffer_name = s:checkNameExistence(l:proxy_file_name)
   if g:vimpyter_use_current_dir
     let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
   else

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -91,7 +91,7 @@ function! vimpyter#createView()
 	let b:ipynb_mode = 1
   " Save references to proxy file and the original
   let b:original_file = l:original_file
-  let b:proxy_file = l:proxy_file
+  call add(g:vimpyter_proxy_files, l:proxy_file)
   let b:ipynb_on = 1
 
 
@@ -119,6 +119,6 @@ function! vimpyter#notebookUpdatesFinished()
       endwhile
     endif
   endif
-  call system('rm ' . b:proxy_file)
+  call system('rm ' . join(g:vimpyter_proxy_files, ' '))
 
 endfunction

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -119,6 +119,7 @@ function! vimpyter#notebookUpdatesFinished()
       endwhile
     endif
   endif
+  execute ':bd' b:proxy_file
   call system('rm ' . b:proxy_file)
 
 endfunction

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -123,8 +123,9 @@ function! vimpyter#notebookUpdatesFinished()
   
   " Close proxy buffers before leave
   for proxy_file in g:vimpyter_proxy_files
-    if bufwinnr(proxy_file) != -1
-      execute ':bw' proxy_file
+    let bufwinnr = bufnr(proxy_file)
+    if bufwinnr != -1
+      execute 'bw ' . bufnr
     endif
   endfor
 

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -74,7 +74,7 @@ function! vimpyter#createView()
   let l:original_dir = substitute(expand('%:p:h'), '\ ', '\\ ', 'g')
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
-  let l:proxy_file_name = '.ipynb_tmp.' . expand('%:t:r')
+  let l:proxy_file_name =  expand('%:t:r') . '.ipynb_tmp'
   let l:proxy_buffer_name = s:checkNameExistence(l:proxy_file_name)
   if g:vimpyter_use_current_dir
     let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
@@ -120,6 +120,14 @@ function! vimpyter#notebookUpdatesFinished()
       endwhile
     endif
   endif
+  
+  " Close proxy buffers before leave
+  for proxy_file in g:vimpyter_proxy_files
+    if bufwinnr(proxy_file) != -1
+      execute ':bw' proxy_file
+    endif
+  endfor
+
   call system('rm ' . join(g:vimpyter_proxy_files, ' '))
 
 endfunction

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -119,7 +119,6 @@ function! vimpyter#notebookUpdatesFinished()
       endwhile
     endif
   endif
-  execute ':bw' b:proxy_file
   call system('rm ' . b:proxy_file)
 
 endfunction

--- a/autoload/vimpyter.vim
+++ b/autoload/vimpyter.vim
@@ -75,7 +75,7 @@ function! vimpyter#createView()
   " Proxies are named accordingly to %:t:r (with appended number for
   " replicating names) (see documentation for more informations)
   let l:proxy_file_name = '~$' . expand('%:t:r')
-  let l:proxy_buffer_name = substitute(s:checkNameExistence(l:proxy_file_name), '~$', '\~\$', 'g')
+  let l:proxy_buffer_name = substitute(s:checkNameExistence(l:proxy_file_name), '\~\$', '\\~\\$', 'g')
   if g:vimpyter_use_current_dir
     let l:proxy_file = l:original_dir . '/' . l:proxy_buffer_name
   else

--- a/plugin/vimpyter.vim
+++ b/plugin/vimpyter.vim
@@ -70,6 +70,7 @@ augroup VimpyterAutoCommands
   autocmd BufNewFile *.ipynb call vimpyter#createView()
   " If view was saved transfer the changes from proxy to original file
   autocmd BufWritePost *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
+  autocmd BufDelete  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
   autocmd VimLeavePre  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
 
 augroup END

--- a/plugin/vimpyter.vim
+++ b/plugin/vimpyter.vim
@@ -53,6 +53,7 @@ else
 endif
 
 let g:vimpyter_buffer_names = {}
+let g:vimpyter_proxy_files = []
 
 " DEFINE COMMANDS
 " command! -nargs=0 VimpyterStartJupyter call vimpyter#startJupyter()
@@ -70,7 +71,7 @@ augroup VimpyterAutoCommands
   autocmd BufNewFile *.ipynb call vimpyter#createView()
   " If view was saved transfer the changes from proxy to original file
   autocmd BufWritePost *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
-  autocmd VimLeavePre  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
+  autocmd VimLeavePre  * call vimpyter#notebookUpdatesFinished()
 
 augroup END
 

--- a/plugin/vimpyter.vim
+++ b/plugin/vimpyter.vim
@@ -70,7 +70,6 @@ augroup VimpyterAutoCommands
   autocmd BufNewFile *.ipynb call vimpyter#createView()
   " If view was saved transfer the changes from proxy to original file
   autocmd BufWritePost *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
-  autocmd BufDelete  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
   autocmd VimLeavePre  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
 
 augroup END

--- a/plugin/vimpyter.vim
+++ b/plugin/vimpyter.vim
@@ -69,8 +69,8 @@ augroup VimpyterAutoCommands
   autocmd BufReadPost *.ipynb call vimpyter#createView()
   autocmd BufNewFile *.ipynb call vimpyter#createView()
   " If view was saved transfer the changes from proxy to original file
-  autocmd BufWritePost *.py~ if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
-  autocmd VimLeavePre  *.py~ if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
+  autocmd BufWritePost *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
+  autocmd VimLeavePre  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
 
 augroup END
 

--- a/plugin/vimpyter.vim
+++ b/plugin/vimpyter.vim
@@ -37,6 +37,7 @@ let g:loaded_vimpyter_plugin_dont_use_this_flag_elsewhere = 1
 " let g:vimpyter_jupyter_notebook_flags = get(g:, 'vimpyter_jupyter_notebook_flags', '')
 " let g:vimpyter_nteract_flags = get(g:, 'vimpyter_nteract_flags', '')
 let g:vimpyter_view_directory = get(g:, 'vimpyter_view_directory', $TMPDIR)
+let g:vimpyter_use_current_dir = get(g:, 'vimpyter_use_current_dir', 1)
 
 " Parse configuration for colorful display of text in cmdline
 let g:vimpyter_color = get(g:, 'vimpyter_color', 0)
@@ -68,8 +69,8 @@ augroup VimpyterAutoCommands
   autocmd BufReadPost *.ipynb call vimpyter#createView()
   autocmd BufNewFile *.ipynb call vimpyter#createView()
   " If view was saved transfer the changes from proxy to original file
-  autocmd BufWritePost *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
-  autocmd VimLeavePre  *.py if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
+  autocmd BufWritePost *.py~ if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#updateNotebook() | endif
+  autocmd VimLeavePre  *.py~ if get(b:, 'ipynb_on', 0) is 1 | call vimpyter#notebookUpdatesFinished() | endif
 
 augroup END
 


### PR DESCRIPTION
Hi, thanks for the plugin. I have some issues with it for my personal usages but cannot find an issue tab to discuss this, so I created this PR to resolve my problems as well as discuss it.

## Added
- `g:vimpyter_use_current_dir` option, for my personal use, I want the proxy file to open in the same directory as the original file so I can have path suggestion as well as it doesn't break my relative imports.
- As a new proxy file will be created in the same directory, I added a `.tmp_ipynb` postfix to the filename to avoid conflicts. E.g: `filename.ipynb` results in `filename.tmp_ipynb.py` proxy file.

## Change
- I want all the proxy files to be deleted (in the case I opened multiples ipynb files) when I'm leaving vim, not only the current `b:proxy_file`. Therefore, I added a `g:vimpyter_proxy_files` variable to track all the proxy files created and delete them before leaving vim.